### PR TITLE
Resolve markers unbound from map (Mapstore bug)

### DIFF
--- a/frontend/src/components/DownloadMapData.vue
+++ b/frontend/src/components/DownloadMapData.vue
@@ -3,10 +3,12 @@
 </template>
 
 <script setup>
-import { useMapStore, selectedFilters } from '@/stores/map'
+import { useMapStore } from '@/stores/map'
 import Papa from 'papaparse'
+import { storeToRefs } from 'pinia'
 
 const mapStore = useMapStore()
+const { currentFilteredData, selectedFilters } = storeToRefs(mapStore)
 const renameColumnInCSV = {
   'figure num': 'Figure Number',
   'figure caption': 'Figure Caption',
@@ -102,8 +104,8 @@ function downloadMapData() {
   } catch (e) {
     console.warn('Heap is not available.')
   }
-  const mapData = mapStore.currentFilteredData
-  const flattenedMapData = flattenMapDataJSON(mapData)
+
+  const flattenedMapData = flattenMapDataJSON(currentFilteredData.value)
 
   const csv = Papa.unparse(flattenedMapData, {
     columns: csvColumns

--- a/frontend/src/components/FilterDrawer.vue
+++ b/frontend/src/components/FilterDrawer.vue
@@ -86,20 +86,23 @@
 
 <script setup>
 import { ref, watch, computed } from 'vue'
+import { storeToRefs } from 'pinia'
 import { usePerceptualModelStore } from '@/stores/perceptual_models'
-import {
-  useMapStore,
+import { useMapStore } from '@/stores/map'
+import { mdiFolderOpen, mdiFolder, mdiCloseCircleOutline } from '@mdi/js'
+
+const perceptualModelStore = usePerceptualModelStore()
+const mapStore = useMapStore()
+
+const {
+  currentFilteredData,
   selectedSpatialZones,
   selectedTemporalZones,
   selectedProcesses,
   searchTerm,
   userTouchedFilter,
   selectedFilters
-} from '@/stores/map'
-import { mdiFolderOpen, mdiFolder, mdiCloseCircleOutline } from '@mdi/js'
-
-const perceptualModelStore = usePerceptualModelStore()
-const mapStore = useMapStore()
+} = storeToRefs(mapStore)
 
 const emit = defineEmits(['selectModel', 'toggle', 'onFilter'])
 
@@ -321,7 +324,7 @@ async function filter() {
     return process && spatial && temporal && search
   }
   mapStore.filterFeatures(filterFunction)
-  const filteredFeatures = mapStore.currentFilteredData
+  const filteredFeatures = currentFilteredData.value
   emit('onFilter', {
     selectedSpatialZones,
     selectedTemporalZones,

--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -20,7 +20,7 @@ import { useMapStore } from '@/stores/map'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material.css'
 
 const mapStore = useMapStore()
-const { layerGroup, allAvailableCoordinates, mapLoaded, userTouchedFilter } = storeToRefs(mapStore)
+const { mapLoaded, userTouchedFilter } = storeToRefs(mapStore)
 
 onUpdated(() => {
   mapStore.leaflet.invalidateSize()
@@ -28,8 +28,8 @@ onUpdated(() => {
 
 onMounted(async () => {
   mapStore.leaflet = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
-  layerGroup.value = new L.LayerGroup()
-  layerGroup.value.addTo(mapStore.leaflet)
+  mapStore.layerGroup = new L.LayerGroup()
+  mapStore.layerGroup.addTo(mapStore.leaflet)
 
   // Initial OSM tile layer
   let CartoDB_PositronNoLabels = L.tileLayer(
@@ -72,14 +72,14 @@ onMounted(async () => {
   await mapStore.fetchPerceptualModelsGeojson()
 
   // Convert to Leaflet LatLngBounds
-  const bounds = L.latLngBounds(allAvailableCoordinates.value)
+  const bounds = L.latLngBounds(mapStore.allAvailableCoordinates)
 
   // Restrict panning to within bounds
   mapStore.leaflet.setMaxBounds(bounds)
 
   // layer toggling
   let mixed = {
-    'Perceptual Models': layerGroup.value,
+    'Perceptual Models': mapStore.layerGroup,
     'Esri Hydro Reference Overlay': Esri_Hydro_Reference_Overlay
   }
 

--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -20,17 +20,16 @@ import { useMapStore } from '@/stores/map'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material.css'
 
 const mapStore = useMapStore()
-const { leaflet, layerGroup, allAvailableCoordinates, mapLoaded, userTouchedFilter } = storeToRefs(mapStore)
-
+const { layerGroup, allAvailableCoordinates, mapLoaded, userTouchedFilter } = storeToRefs(mapStore)
 
 onUpdated(() => {
-  leaflet.value.invalidateSize()
+  mapStore.leaflet.invalidateSize()
 })
 
 onMounted(async () => {
-  leaflet.value = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
+  mapStore.leaflet = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
   layerGroup.value = new L.LayerGroup()
-  layerGroup.value.addTo(leaflet.value)
+  layerGroup.value.addTo(mapStore.leaflet)
 
   // Initial OSM tile layer
   let CartoDB_PositronNoLabels = L.tileLayer(
@@ -66,8 +65,8 @@ onMounted(async () => {
     Esri_WorldImagery
   }
 
-  Esri_WorldImagery.addTo(leaflet.value)
-  Esri_Hydro_Reference_Overlay.addTo(leaflet.value)
+  Esri_WorldImagery.addTo(mapStore.leaflet)
+  Esri_Hydro_Reference_Overlay.addTo(mapStore.leaflet)
 
   // query the api for the features
   await mapStore.fetchPerceptualModelsGeojson()
@@ -76,7 +75,7 @@ onMounted(async () => {
   const bounds = L.latLngBounds(allAvailableCoordinates.value)
 
   // Restrict panning to within bounds
-  leaflet.value.setMaxBounds(bounds)
+  mapStore.leaflet.setMaxBounds(bounds)
 
   // layer toggling
   let mixed = {
@@ -89,12 +88,12 @@ onMounted(async () => {
   //  */
 
   // Layer Control
-  L.control.layers(baselayers, mixed).addTo(leaflet.value)
+  L.control.layers(baselayers, mixed).addTo(mapStore.leaflet)
 
   /*
    * LEAFLET EVENT HANDLERS
    */
-  leaflet.value.on('click', function (e) {
+  mapStore.leaflet.on('click', function (e) {
     mapClick(e)
   })
 

--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -13,23 +13,23 @@
 <script setup>
 import 'leaflet/dist/leaflet.css'
 import L from 'leaflet'
+import { storeToRefs } from 'pinia'
 import * as esriLeaflet from 'esri-leaflet'
 import { onMounted, onUpdated } from 'vue'
 import { useMapStore, userTouchedFilter } from '@/stores/map'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material.css'
 
 const mapStore = useMapStore()
+const { leaflet, layerGroup, allAvailableCoordinates, mapLoaded } = storeToRefs(mapStore)
 
 onUpdated(() => {
-  mapStore.leaflet.invalidateSize()
+  leaflet.value.invalidateSize()
 })
 
 onMounted(async () => {
-  let leaflet = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
-  mapStore.leaflet = leaflet
-  let layerGroup = new L.LayerGroup()
-  mapStore.layerGroup = layerGroup
-  layerGroup.addTo(leaflet)
+  leaflet.value = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
+  layerGroup.value = new L.LayerGroup()
+  layerGroup.value.addTo(leaflet.value)
 
   // Initial OSM tile layer
   let CartoDB_PositronNoLabels = L.tileLayer(
@@ -65,21 +65,21 @@ onMounted(async () => {
     Esri_WorldImagery
   }
 
-  Esri_WorldImagery.addTo(leaflet)
-  Esri_Hydro_Reference_Overlay.addTo(leaflet)
+  Esri_WorldImagery.addTo(leaflet.value)
+  Esri_Hydro_Reference_Overlay.addTo(leaflet.value)
 
   // query the api for the features
   await mapStore.fetchPerceptualModelsGeojson()
 
   // Convert to Leaflet LatLngBounds
-  const bounds = L.latLngBounds(mapStore.allAvailableCoordinates)
+  const bounds = L.latLngBounds(allAvailableCoordinates.value)
 
   // Restrict panning to within bounds
-  leaflet.setMaxBounds(bounds)
+  leaflet.value.setMaxBounds(bounds)
 
   // layer toggling
   let mixed = {
-    'Perceptual Models': layerGroup,
+    'Perceptual Models': layerGroup.value,
     'Esri Hydro Reference Overlay': Esri_Hydro_Reference_Overlay
   }
 
@@ -88,16 +88,16 @@ onMounted(async () => {
   //  */
 
   // Layer Control
-  L.control.layers(baselayers, mixed).addTo(leaflet)
+  L.control.layers(baselayers, mixed).addTo(leaflet.value)
 
   /*
    * LEAFLET EVENT HANDLERS
    */
-  leaflet.on('click', function (e) {
+  leaflet.value.on('click', function (e) {
     mapClick(e)
   })
 
-  mapStore.mapLoaded = true
+  mapLoaded.value = true
 })
 
 /**

--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -1,10 +1,7 @@
 <template>
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
   <div v-show="$route.meta.showMap" id="mapContainer">
-    <div
-      v-if="userTouchedFilter && mapStore.currentFilteredData.length === 0"
-      class="no-data-overlay"
-    >
+    <div v-if="userTouchedFilter && currentFilteredData.length === 0" class="no-data-overlay">
       <span>No data found</span>
     </div>
   </div>
@@ -20,7 +17,7 @@ import { useMapStore } from '@/stores/map'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material.css'
 
 const mapStore = useMapStore()
-const { mapLoaded, userTouchedFilter } = storeToRefs(mapStore)
+const { mapLoaded, userTouchedFilter, currentFilteredData } = storeToRefs(mapStore)
 
 onUpdated(() => {
   mapStore.leaflet.invalidateSize()

--- a/frontend/src/components/TheLeafletMap.vue
+++ b/frontend/src/components/TheLeafletMap.vue
@@ -15,22 +15,22 @@ import 'leaflet/dist/leaflet.css'
 import L from 'leaflet'
 import { storeToRefs } from 'pinia'
 import * as esriLeaflet from 'esri-leaflet'
-import { onMounted, onUpdated, toRaw } from 'vue'
+import { onMounted, onUpdated } from 'vue'
 import { useMapStore } from '@/stores/map'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material.css'
 
 const mapStore = useMapStore()
 const { leaflet, layerGroup, allAvailableCoordinates, mapLoaded, userTouchedFilter } = storeToRefs(mapStore)
-let rawLeaflet = toRaw(leaflet)
+
 
 onUpdated(() => {
-  rawLeaflet.invalidateSize()
+  leaflet.value.invalidateSize()
 })
 
 onMounted(async () => {
-  rawLeaflet = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
+  leaflet.value = L.map('mapContainer', { minZoom: 2 }).setView([0, 11], 2)
   layerGroup.value = new L.LayerGroup()
-  layerGroup.value.addTo(rawLeaflet)
+  layerGroup.value.addTo(leaflet.value)
 
   // Initial OSM tile layer
   let CartoDB_PositronNoLabels = L.tileLayer(
@@ -66,8 +66,8 @@ onMounted(async () => {
     Esri_WorldImagery
   }
 
-  Esri_WorldImagery.addTo(rawLeaflet)
-  Esri_Hydro_Reference_Overlay.addTo(rawLeaflet)
+  Esri_WorldImagery.addTo(leaflet.value)
+  Esri_Hydro_Reference_Overlay.addTo(leaflet.value)
 
   // query the api for the features
   await mapStore.fetchPerceptualModelsGeojson()
@@ -76,7 +76,7 @@ onMounted(async () => {
   const bounds = L.latLngBounds(allAvailableCoordinates.value)
 
   // Restrict panning to within bounds
-  rawLeaflet.setMaxBounds(bounds)
+  leaflet.value.setMaxBounds(bounds)
 
   // layer toggling
   let mixed = {
@@ -89,17 +89,16 @@ onMounted(async () => {
   //  */
 
   // Layer Control
-  L.control.layers(baselayers, mixed).addTo(rawLeaflet)
+  L.control.layers(baselayers, mixed).addTo(leaflet.value)
 
   /*
    * LEAFLET EVENT HANDLERS
    */
-  rawLeaflet.on('click', function (e) {
+  leaflet.value.on('click', function (e) {
     mapClick(e)
   })
 
   mapLoaded.value = true
-  leaflet.value = rawLeaflet
 })
 
 /**

--- a/frontend/src/stores/map.js
+++ b/frontend/src/stores/map.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { ENDPOINTS } from '@/constants'
 import L from 'leaflet'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material'
@@ -7,13 +7,13 @@ import 'leaflet.markercluster'
 import citationMatchingFileNames from '@/assets/citation_and_images_matching.json'
 
 export const useMapStore = defineStore('map', () => {
-  const leaflet = ref(null)
+  const leaflet = shallowRef(null)
   const layerGroup = ref(null)
   const modelFeatures = ref({})
   const perceptualModelsGeojson = ref([])
   const mapLoaded = ref(false)
   let currentFilteredData = ref([])
-  const allAvailableCoordinates = []
+  const allAvailableCoordinates = ref([])
   const markerClusterGroup = L.markerClusterGroup({
     iconCreateFunction: (cluster) => {
       const childCount = cluster.getChildCount()
@@ -121,7 +121,7 @@ export const useMapStore = defineStore('map', () => {
       content += `${feature.properties.temporal_zone_type.temporal_property}`
     }
 
-    allAvailableCoordinates.push(
+    allAvailableCoordinates.value.push(
       adjustLatLon(feature.properties.location.lat, feature.properties.location.lon)
     )
 

--- a/frontend/src/stores/map.js
+++ b/frontend/src/stores/map.js
@@ -7,6 +7,12 @@ import 'leaflet.markercluster'
 import citationMatchingFileNames from '@/assets/citation_and_images_matching.json'
 
 export const useMapStore = defineStore('map', () => {
+  const selectedSpatialZones = ref([])
+  const selectedTemporalZones = ref([])
+  const selectedProcesses = ref([])
+  const searchTerm = ref(null)
+  const userTouchedFilter = ref(false)
+  const selectedFilters = ref({})
   const leaflet = shallowRef(null)
   const layerGroup = shallowRef(null)
   const allAvailableCoordinates = shallowRef([])
@@ -234,12 +240,12 @@ export const useMapStore = defineStore('map', () => {
     filterFeatures,
     resetFilter,
     currentFilteredData,
-    allAvailableCoordinates
+    allAvailableCoordinates,
+    selectedSpatialZones,
+    selectedTemporalZones,
+    selectedProcesses,
+    searchTerm,
+    userTouchedFilter,
+    selectedFilters
   }
 })
-export const selectedSpatialZones = ref([])
-export const selectedTemporalZones = ref([])
-export const selectedProcesses = ref([])
-export const searchTerm = ref(null)
-export const userTouchedFilter = ref(false)
-export const selectedFilters = ref({})

--- a/frontend/src/stores/map.js
+++ b/frontend/src/stores/map.js
@@ -8,12 +8,12 @@ import citationMatchingFileNames from '@/assets/citation_and_images_matching.jso
 
 export const useMapStore = defineStore('map', () => {
   const leaflet = shallowRef(null)
-  const layerGroup = ref(null)
+  const layerGroup = shallowRef(null)
+  const allAvailableCoordinates = shallowRef([])
   const modelFeatures = ref({})
   const perceptualModelsGeojson = ref([])
   const mapLoaded = ref(false)
   let currentFilteredData = ref([])
-  const allAvailableCoordinates = ref([])
   const markerClusterGroup = L.markerClusterGroup({
     iconCreateFunction: (cluster) => {
       const childCount = cluster.getChildCount()

--- a/frontend/src/stores/map.js
+++ b/frontend/src/stores/map.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref, shallowRef } from 'vue'
+import { ref } from 'vue'
 import { ENDPOINTS } from '@/constants'
 import L from 'leaflet'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material'
@@ -7,7 +7,7 @@ import 'leaflet.markercluster'
 import citationMatchingFileNames from '@/assets/citation_and_images_matching.json'
 
 export const useMapStore = defineStore('map', () => {
-  const leaflet = shallowRef(null)
+  const leaflet = ref(null)
   const layerGroup = ref(null)
   const modelFeatures = ref({})
   const perceptualModelsGeojson = ref([])

--- a/frontend/src/stores/map.js
+++ b/frontend/src/stores/map.js
@@ -1,5 +1,5 @@
 import { defineStore } from 'pinia'
-import { ref } from 'vue'
+import { ref, shallowRef } from 'vue'
 import { ENDPOINTS } from '@/constants'
 import L from 'leaflet'
 import 'leaflet-iconmaterial/dist/leaflet.icon-material'
@@ -7,7 +7,7 @@ import 'leaflet.markercluster'
 import citationMatchingFileNames from '@/assets/citation_and_images_matching.json'
 
 export const useMapStore = defineStore('map', () => {
-  const leaflet = ref(null)
+  const leaflet = shallowRef(null)
   const layerGroup = ref(null)
   const modelFeatures = ref({})
   const perceptualModelsGeojson = ref([])

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -60,12 +60,9 @@ import TheLeafletMap from '@/components/TheLeafletMap.vue'
 import { mdiChevronRight, mdiChevronLeft } from '@mdi/js'
 import { useMapStore } from '@/stores/map'
 import { useDisplay } from 'vuetify'
-import { storeToRefs } from 'pinia'
 
 const { mdAndDown } = useDisplay()
 const mapStore = useMapStore()
-
-const { leaflet } = storeToRefs(mapStore)
 
 const showFilterDrawer = ref(true)
 const showDataDrawer = ref(true)
@@ -94,21 +91,21 @@ const onFilter = (data) => {
 }
 
 const toggleFilterDrawer = async () => {
-  const center = leaflet.value.getCenter()
+  const center = mapStore.leaflet.getCenter()
   showFilterDrawer.value = !showFilterDrawer.value
   await nextTick()
-  leaflet.value.invalidateSize(true)
-  leaflet.value.setView(center)
+  mapStore.leaflet.invalidateSize(true)
+  mapStore.leaflet.setView(center)
 }
 
 const toggleDataDrawer = async () => {
   // get the center of the map before the drawer is toggled
-  const center = leaflet.value.getCenter()
+  const center = mapStore.leaflet.getCenter()
   showDataDrawer.value = !showDataDrawer.value
   await nextTick()
-  leaflet.value.invalidateSize(true)
+  mapStore.leaflet.invalidateSize(true)
   // set the center of the map after the drawer is toggled
-  leaflet.value.setView(center)
+  mapStore.leaflet.setView(center)
 }
 
 const getCols = computed(() => {

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script setup>
-import { ref, computed, nextTick, toRaw } from 'vue'
+import { ref, computed, nextTick } from 'vue'
 import FilterDrawer from '@/components/FilterDrawer.vue'
 import DataViewDrawer from '@/components/DataViewDrawer.vue'
 import TheLeafletMap from '@/components/TheLeafletMap.vue'
@@ -66,7 +66,6 @@ const { mdAndDown } = useDisplay()
 const mapStore = useMapStore()
 
 const { leaflet } = storeToRefs(mapStore)
-const rawLeaflet = toRaw(leaflet)
 
 const showFilterDrawer = ref(true)
 const showDataDrawer = ref(true)
@@ -95,23 +94,21 @@ const onFilter = (data) => {
 }
 
 const toggleFilterDrawer = async () => {
-  const center = rawLeaflet.getCenter()
+  const center = leaflet.value.getCenter()
   showFilterDrawer.value = !showFilterDrawer.value
   await nextTick()
-  rawLeaflet.invalidateSize(true)
-  rawLeaflet.setView(center)
-  leaflet.value = rawLeaflet
+  leaflet.value.invalidateSize(true)
+  leaflet.value.setView(center)
 }
 
 const toggleDataDrawer = async () => {
   // get the center of the map before the drawer is toggled
-  const center = rawLeaflet.getCenter()
+  const center = leaflet.value.getCenter()
   showDataDrawer.value = !showDataDrawer.value
   await nextTick()
-  rawLeaflet.invalidateSize(true)
+  leaflet.value.invalidateSize(true)
   // set the center of the map after the drawer is toggled
-  rawLeaflet.setView(center)
-  leaflet.value = rawLeaflet
+  leaflet.value.setView(center)
 }
 
 const getCols = computed(() => {

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -60,9 +60,12 @@ import TheLeafletMap from '@/components/TheLeafletMap.vue'
 import { mdiChevronRight, mdiChevronLeft } from '@mdi/js'
 import { useMapStore } from '@/stores/map'
 import { useDisplay } from 'vuetify'
+import { storeToRefs } from 'pinia'
 
 const { mdAndDown } = useDisplay()
 const mapStore = useMapStore()
+
+const { leaflet } = storeToRefs(mapStore)
 
 const showFilterDrawer = ref(true)
 const showDataDrawer = ref(true)
@@ -91,21 +94,21 @@ const onFilter = (data) => {
 }
 
 const toggleFilterDrawer = async () => {
-  const center = mapStore.leaflet.getCenter()
+  const center = leaflet.value.getCenter()
   showFilterDrawer.value = !showFilterDrawer.value
   await nextTick()
-  mapStore.leaflet.invalidateSize(true)
-  mapStore.leaflet.setView(center)
+  leaflet.value.invalidateSize(true)
+  leaflet.value.setView(center)
 }
 
 const toggleDataDrawer = async () => {
   // get the center of the map before the drawer is toggled
-  const center = mapStore.leaflet.getCenter()
+  const center = leaflet.value.getCenter()
   showDataDrawer.value = !showDataDrawer.value
   await nextTick()
-  mapStore.leaflet.invalidateSize(true)
+  leaflet.value.invalidateSize(true)
   // set the center of the map after the drawer is toggled
-  mapStore.leaflet.setView(center)
+  leaflet.value.setView(center)
 }
 
 const getCols = computed(() => {

--- a/frontend/src/views/MapView.vue
+++ b/frontend/src/views/MapView.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script setup>
-import { ref, computed, nextTick } from 'vue'
+import { ref, computed, nextTick, toRaw } from 'vue'
 import FilterDrawer from '@/components/FilterDrawer.vue'
 import DataViewDrawer from '@/components/DataViewDrawer.vue'
 import TheLeafletMap from '@/components/TheLeafletMap.vue'
@@ -66,6 +66,7 @@ const { mdAndDown } = useDisplay()
 const mapStore = useMapStore()
 
 const { leaflet } = storeToRefs(mapStore)
+const rawLeaflet = toRaw(leaflet)
 
 const showFilterDrawer = ref(true)
 const showDataDrawer = ref(true)
@@ -94,21 +95,23 @@ const onFilter = (data) => {
 }
 
 const toggleFilterDrawer = async () => {
-  const center = leaflet.value.getCenter()
+  const center = rawLeaflet.getCenter()
   showFilterDrawer.value = !showFilterDrawer.value
   await nextTick()
-  leaflet.value.invalidateSize(true)
-  leaflet.value.setView(center)
+  rawLeaflet.invalidateSize(true)
+  rawLeaflet.setView(center)
+  leaflet.value = rawLeaflet
 }
 
 const toggleDataDrawer = async () => {
   // get the center of the map before the drawer is toggled
-  const center = leaflet.value.getCenter()
+  const center = rawLeaflet.getCenter()
   showDataDrawer.value = !showDataDrawer.value
   await nextTick()
-  leaflet.value.invalidateSize(true)
+  rawLeaflet.invalidateSize(true)
   // set the center of the map after the drawer is toggled
-  leaflet.value.setView(center)
+  rawLeaflet.setView(center)
+  leaflet.value = rawLeaflet
 }
 
 const getCols = computed(() => {


### PR DESCRIPTION
We have witnessed the leaflet markers "becoming unbound" from the map -- so when panning they do not remain linked to the underlying map.

To reproduce the issue:
1. Zoom in until you can see single map makers instead of just clusters
2. Click one of the markers to open the pop-up
3. Close the pop-up
4. Pan the map
5. Zoom in/out
6. See that the markers are unbound and remain so until you zoom out enough that they become part of a cluster again

Here is a video showing the issue:

https://github.com/user-attachments/assets/feccb099-0681-447b-8bf7-d048b09b177d


I believe same is this issue:
https://stackoverflow.com/questions/65981712/uncaught-typeerror-this-map-is-null-vue-js-3-leaflet